### PR TITLE
Only install oh-my-zsh for users that exist.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ search( :users, "shell:*zsh AND NOT action:remove" ).each do |u|
     group user_id
     action :checkout
     not_if "test -d /home/#{user_id}/.oh-my-zsh"
+    only_if { ::File.exists?("/home/#{user_id}") }
   end
 
   theme = data_bag_item( "users", user_id )["oh-my-zsh-theme"]
@@ -40,5 +41,6 @@ search( :users, "shell:*zsh AND NOT action:remove" ).each do |u|
     group user_id
     variables( :theme => ( theme || node[:ohmyzsh][:theme] ))
     action :create_if_missing
+    only_if { ::File.exists?("/home/#{user_id}") }
   end
 end

--- a/recipes/shared.rb
+++ b/recipes/shared.rb
@@ -12,6 +12,7 @@ search( :users, "shell:*zsh" ).each do |u|
   link "/home/#{user_id}/.oh-my-zsh" do
     to "/usr/src/oh-my-zsh"
     not_if "test -d /home/#{user_id}/.oh-my-zsh"
+    only_if { ::File.exists?("/home/#{user_id}") }
   end
 
   template "/home/#{user_id}/.zshrc" do
@@ -20,5 +21,6 @@ search( :users, "shell:*zsh" ).each do |u|
     group user_id
     variables( :theme => ( theme || node[:ohmyzsh][:theme] ))
     action :create_if_missing
+    only_if { ::File.exists?("/home/#{user_id}") }
   end
 end


### PR DESCRIPTION
Not all items in the `users` data bag may actually be created as users. For example, `recipe[users::sysadmins]` only creates users in the `sysadmins` group, whereas other recipes may use other criteria to decide which users to create under which circumstances.

The recipes in this cookbook should therefore not assume that every item in the `users` data bag has been created as a user on the system. Doing so can cause these recipes to fail when they attempt to add files to the home directories of users that do not exist.